### PR TITLE
[Feat] 스톱워치 구현

### DIFF
--- a/iClone_Clock/iClone_Clock.xcodeproj/project.pbxproj
+++ b/iClone_Clock/iClone_Clock.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		298079432A8D110900D37113 /* SearchBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 298079422A8D110900D37113 /* SearchBarView.swift */; };
 		2980794B2A8E212F00D37113 /* locationInfoDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2980794A2A8E212F00D37113 /* locationInfoDictionary.swift */; };
 		29AEDE1C2A93498F00ABB78B /* GetFirstConsonant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29AEDE1B2A93498F00ABB78B /* GetFirstConsonant.swift */; };
+		F00818702A9F7DB40011B4FA /* LapListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F008186F2A9F7DB40011B4FA /* LapListView.swift */; };
+		F00818742A9F7E450011B4FA /* StopwatchTimerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00818732A9F7E450011B4FA /* StopwatchTimerView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -41,6 +43,8 @@
 		298079422A8D110900D37113 /* SearchBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarView.swift; sourceTree = "<group>"; };
 		2980794A2A8E212F00D37113 /* locationInfoDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = locationInfoDictionary.swift; sourceTree = "<group>"; };
 		29AEDE1B2A93498F00ABB78B /* GetFirstConsonant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetFirstConsonant.swift; sourceTree = "<group>"; };
+		F008186F2A9F7DB40011B4FA /* LapListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LapListView.swift; sourceTree = "<group>"; };
+		F00818732A9F7E450011B4FA /* StopwatchTimerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopwatchTimerView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -77,7 +81,7 @@
 				298079172A8CAE7B00D37113 /* ContentView.swift */,
 				298079232A8CDE3400D37113 /* View */,
 				2980793B2A8D00E200D37113 /* Model */,
-				29AEDE192A9348E400ABB78B /* Component */,
+				29AEDE192A9348E400ABB78B /* Utilities */,
 				298079192A8CAE7D00D37113 /* Assets.xcassets */,
 				2980791B2A8CAE7D00D37113 /* Preview Content */,
 			);
@@ -127,6 +131,8 @@
 			isa = PBXGroup;
 			children = (
 				2980792E2A8CE00C00D37113 /* StopwatchView.swift */,
+				F00818732A9F7E450011B4FA /* StopwatchTimerView.swift */,
+				F008186F2A9F7DB40011B4FA /* LapListView.swift */,
 			);
 			path = Stopwatch;
 			sourceTree = "<group>";
@@ -148,12 +154,12 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
-		29AEDE192A9348E400ABB78B /* Component */ = {
+		29AEDE192A9348E400ABB78B /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
 				29AEDE1B2A93498F00ABB78B /* GetFirstConsonant.swift */,
 			);
-			path = Component;
+			path = Utilities;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -229,10 +235,12 @@
 			files = (
 				29AEDE1C2A93498F00ABB78B /* GetFirstConsonant.swift in Sources */,
 				298079312A8CE01600D37113 /* TimerView.swift in Sources */,
+				F00818742A9F7E450011B4FA /* StopwatchTimerView.swift in Sources */,
 				298079182A8CAE7B00D37113 /* ContentView.swift in Sources */,
 				298079292A8CDFE700D37113 /* MainView.swift in Sources */,
 				298079412A8D100600D37113 /* WorldClockModel.swift in Sources */,
 				298079432A8D110900D37113 /* SearchBarView.swift in Sources */,
+				F00818702A9F7DB40011B4FA /* LapListView.swift in Sources */,
 				2980792F2A8CE00C00D37113 /* StopwatchView.swift in Sources */,
 				2980792D2A8CE00300D37113 /* AlarmView.swift in Sources */,
 				2980792B2A8CDFFB00D37113 /* WorldClockView.swift in Sources */,

--- a/iClone_Clock/iClone_Clock.xcodeproj/project.pbxproj
+++ b/iClone_Clock/iClone_Clock.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		298079432A8D110900D37113 /* SearchBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 298079422A8D110900D37113 /* SearchBarView.swift */; };
 		2980794B2A8E212F00D37113 /* locationInfoDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2980794A2A8E212F00D37113 /* locationInfoDictionary.swift */; };
 		29AEDE1C2A93498F00ABB78B /* GetFirstConsonant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29AEDE1B2A93498F00ABB78B /* GetFirstConsonant.swift */; };
+		29EAB4182AA5CE09004E5429 /* StopwatchObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29EAB4172AA5CE09004E5429 /* StopwatchObservable.swift */; };
 		F00818702A9F7DB40011B4FA /* LapListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F008186F2A9F7DB40011B4FA /* LapListView.swift */; };
 		F00818742A9F7E450011B4FA /* StopwatchTimerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F00818732A9F7E450011B4FA /* StopwatchTimerView.swift */; };
 /* End PBXBuildFile section */
@@ -43,6 +44,7 @@
 		298079422A8D110900D37113 /* SearchBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBarView.swift; sourceTree = "<group>"; };
 		2980794A2A8E212F00D37113 /* locationInfoDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = locationInfoDictionary.swift; sourceTree = "<group>"; };
 		29AEDE1B2A93498F00ABB78B /* GetFirstConsonant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetFirstConsonant.swift; sourceTree = "<group>"; };
+		29EAB4172AA5CE09004E5429 /* StopwatchObservable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopwatchObservable.swift; sourceTree = "<group>"; };
 		F008186F2A9F7DB40011B4FA /* LapListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LapListView.swift; sourceTree = "<group>"; };
 		F00818732A9F7E450011B4FA /* StopwatchTimerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopwatchTimerView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -80,6 +82,7 @@
 				298079152A8CAE7B00D37113 /* iClone_ClockApp.swift */,
 				298079172A8CAE7B00D37113 /* ContentView.swift */,
 				298079232A8CDE3400D37113 /* View */,
+				29EAB4162AA5CDE8004E5429 /* Observable */,
 				2980793B2A8D00E200D37113 /* Model */,
 				29AEDE192A9348E400ABB78B /* Utilities */,
 				298079192A8CAE7D00D37113 /* Assets.xcassets */,
@@ -162,6 +165,14 @@
 			path = Utilities;
 			sourceTree = "<group>";
 		};
+		29EAB4162AA5CDE8004E5429 /* Observable */ = {
+			isa = PBXGroup;
+			children = (
+				29EAB4172AA5CE09004E5429 /* StopwatchObservable.swift */,
+			);
+			path = Observable;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -239,6 +250,7 @@
 				298079182A8CAE7B00D37113 /* ContentView.swift in Sources */,
 				298079292A8CDFE700D37113 /* MainView.swift in Sources */,
 				298079412A8D100600D37113 /* WorldClockModel.swift in Sources */,
+				29EAB4182AA5CE09004E5429 /* StopwatchObservable.swift in Sources */,
 				298079432A8D110900D37113 /* SearchBarView.swift in Sources */,
 				F00818702A9F7DB40011B4FA /* LapListView.swift in Sources */,
 				2980792F2A8CE00C00D37113 /* StopwatchView.swift in Sources */,

--- a/iClone_Clock/iClone_Clock/Observable/StopwatchObservable.swift
+++ b/iClone_Clock/iClone_Clock/Observable/StopwatchObservable.swift
@@ -1,0 +1,36 @@
+//
+//  StopwatchObservable.swift
+//  iClone_Clock
+//
+//  Created by hyunjun on 2023/09/04.
+//
+
+import Foundation
+import SwiftUI
+
+class StopwatchObserable: ObservableObject {
+    
+    @Published var counter = 0
+    @Published var timer = Timer()
+    @Published var laps: [Int] = []
+    
+    func startTimer() {
+        self.timer = Timer.scheduledTimer(withTimeInterval: 0.01, repeats: true) { _ in
+            self.counter += 1
+        }
+    }
+    
+    func stopTimer() {
+        timer.invalidate()
+    }
+    
+    func resetTimer() {
+        self.counter = 0
+        laps.removeAll()
+    }
+    
+    func lapTimer() {
+        laps.append(counter)
+        self.counter = 0
+    }
+}

--- a/iClone_Clock/iClone_Clock/Observable/StopwatchObservable.swift
+++ b/iClone_Clock/iClone_Clock/Observable/StopwatchObservable.swift
@@ -64,8 +64,6 @@ extension StopwatchObserable {
         let minLap = laps.min() ?? 0
         
         switch (lap == minLap, lap == maxLap) {
-        case (true, true):
-            return Color.primary
         case (_, true):
             return Color.red
         case (true, _):

--- a/iClone_Clock/iClone_Clock/Observable/StopwatchObservable.swift
+++ b/iClone_Clock/iClone_Clock/Observable/StopwatchObservable.swift
@@ -7,21 +7,28 @@
 
 import Foundation
 import SwiftUI
+import Combine
 
 class StopwatchObserable: ObservableObject {
     
     @Published var counter = 0
-    @Published var timer = Timer()
     @Published var laps: [Int] = []
+    /// Combine 스트림을 구독할 때 AnyCancellable 객체로 초기화
+    /// 뷰가 해제될 때 Combine 스트림의 구독을 취소해야 함 - 메모리 누수 방지
+    
+    private var timer: AnyCancellable?
     
     func startTimer() {
-        self.timer = Timer.scheduledTimer(withTimeInterval: 0.01, repeats: true) { _ in
-            self.counter += 1
-        }
+        timer = Timer.publish(every: 0.01, on: .main, in: .common)
+            .autoconnect()
+            .sink { _ in
+                self.counter += 1
+            }
     }
     
     func stopTimer() {
-        timer.invalidate()
+        /// 옵셔널 체이닝, nil 이 아닌 경우에만 호출
+        timer?.cancel()
     }
     
     func resetTimer() {
@@ -32,5 +39,39 @@ class StopwatchObserable: ObservableObject {
     func lapTimer() {
         laps.append(counter)
         self.counter = 0
+    }
+}
+
+
+extension StopwatchObserable {
+    
+    /// 0.01 초 단위로 올라간 숫자를 00:00:00 타이머 형태로 변환해주는 함수입니다.
+    /// - Parameter counter: Int 값을 넣어주세요
+    /// - Returns: 00:00:00 타이머 형태
+    func formattedTime(_ counter: Int) -> String {
+        let minutes = counter / 6000
+        let seconds = counter / 100 % 60
+        let milliseconds = counter % 100
+        
+        return String(format: "%02d:%02d:%02d", minutes, seconds, milliseconds)
+    }
+    
+    /// 최대 최솟값을 판별하여 색상을 넣어줍니다.
+    /// - Parameter lap: 랩
+    /// - Returns: 색상
+    func lapColor(_ lap: Int) -> Color {
+        let maxLap = laps.max() ?? 0
+        let minLap = laps.min() ?? 0
+        
+        switch (lap == minLap, lap == maxLap) {
+        case (true, true):
+            return Color.primary
+        case (_, true):
+            return Color.red
+        case (true, _):
+            return Color.green
+        default:
+            return Color.primary
+        }
     }
 }

--- a/iClone_Clock/iClone_Clock/Utilities/GetFirstConsonant.swift
+++ b/iClone_Clock/iClone_Clock/Utilities/GetFirstConsonant.swift
@@ -11,7 +11,7 @@ let hangulConsonant = ["ㄱ","ㄲ","ㄴ","ㄷ","ㄸ","ㄹ","ㅁ","ㅂ","ㅃ","�
 
 /// 첫 모음을 가져오는 함수
 /// - Parameter word: 검색어
-/// - Returns: 해당 단어의 첫 모음
+/// - Returns: 해당 한글 단어의 첫 모음
 func getFirstConsonant(word: String) -> String {
     let unicode = word.unicodeScalars[word.unicodeScalars.startIndex].value
 

--- a/iClone_Clock/iClone_Clock/View/Stopwatch/LapListView.swift
+++ b/iClone_Clock/iClone_Clock/View/Stopwatch/LapListView.swift
@@ -9,29 +9,28 @@ import SwiftUI
 
 struct LapListView: View {
     
-    @ObservedObject var observable: StopwatchObserable
+    @StateObject var observable: StopwatchObserable
     
     var body: some View {
         
         let lapsCount = observable.laps.count
         let laps = observable.laps
         
-        let maxLap = laps.max() ?? 0
-        let minLap = laps.min() ?? 0
-        
         List {
             HStack {
                 Text("랩 \(lapsCount + 1)")
                 Spacer()
-                Text("\(observable.counter)")
+                Text(observable.formattedTime(observable.counter))
+                    .monospacedDigit()
             }
             if !observable.laps.isEmpty {
                 ForEach(laps.enumerated().reversed(), id: \.offset) { index, lap in
                     HStack {
                         Text("랩 \(index + 1)")
                         Spacer()
-                        Text("\(lap)")
-                            .foregroundColor(lap == maxLap ? .red : lap == minLap ? .green : .primary)
+                        Text(observable.formattedTime(lap))
+                            .foregroundColor(observable.lapColor(lap))
+                            .monospacedDigit()
                     }
                 }
             }

--- a/iClone_Clock/iClone_Clock/View/Stopwatch/LapListView.swift
+++ b/iClone_Clock/iClone_Clock/View/Stopwatch/LapListView.swift
@@ -1,0 +1,24 @@
+//
+//  LapListView.swift
+//  iClone_Clock
+//
+//  Created by Hyunjun Kim on 2023/08/30.
+//
+
+import SwiftUI
+
+struct LapListView: View {
+    var body: some View {
+        List {
+            Text("hello")
+        }
+        .listStyle(.inset)
+        .padding(.trailing)
+    }
+}
+
+struct LapListView_Previews: PreviewProvider {
+    static var previews: some View {
+        LapListView()
+    }
+}

--- a/iClone_Clock/iClone_Clock/View/Stopwatch/LapListView.swift
+++ b/iClone_Clock/iClone_Clock/View/Stopwatch/LapListView.swift
@@ -12,19 +12,15 @@ struct LapListView: View {
     @StateObject var observable: StopwatchObserable
     
     var body: some View {
-        
-        let lapsCount = observable.laps.count
-        let laps = observable.laps
-        
         List {
             HStack {
-                Text("랩 \(lapsCount + 1)")
+                Text("랩 \(observable.laps.count + 1)")
                 Spacer()
                 Text(observable.formattedTime(observable.counter))
                     .monospacedDigit()
             }
             if !observable.laps.isEmpty {
-                ForEach(laps.enumerated().reversed(), id: \.offset) { index, lap in
+                ForEach(observable.laps.enumerated().reversed(), id: \.offset) { index, lap in
                     HStack {
                         Text("랩 \(index + 1)")
                         Spacer()

--- a/iClone_Clock/iClone_Clock/View/Stopwatch/LapListView.swift
+++ b/iClone_Clock/iClone_Clock/View/Stopwatch/LapListView.swift
@@ -8,17 +8,40 @@
 import SwiftUI
 
 struct LapListView: View {
+    
+    @ObservedObject var observable: StopwatchObserable
+    
     var body: some View {
+        
+        let lapsCount = observable.laps.count
+        let laps = observable.laps
+        
+        let maxLap = laps.max() ?? 0
+        let minLap = laps.min() ?? 0
+        
         List {
-            Text("hello")
+            HStack {
+                Text("랩 \(lapsCount + 1)")
+                Spacer()
+                Text("\(observable.counter)")
+            }
+            if !observable.laps.isEmpty {
+                ForEach(laps.enumerated().reversed(), id: \.offset) { index, lap in
+                    HStack {
+                        Text("랩 \(index + 1)")
+                        Spacer()
+                        Text("\(lap)")
+                            .foregroundColor(lap == maxLap ? .red : lap == minLap ? .green : .primary)
+                    }
+                }
+            }
         }
-        .listStyle(.inset)
-        .padding(.trailing)
+        .listStyle(.plain)
     }
 }
 
 struct LapListView_Previews: PreviewProvider {
     static var previews: some View {
-        LapListView()
+        LapListView(observable: StopwatchObserable())
     }
 }

--- a/iClone_Clock/iClone_Clock/View/Stopwatch/StopwatchTimerView.swift
+++ b/iClone_Clock/iClone_Clock/View/Stopwatch/StopwatchTimerView.swift
@@ -1,0 +1,26 @@
+//
+//  StopwatchTimerView.swift
+//  iClone_Clock
+//
+//  Created by Hyunjun Kim on 2023/08/30.
+//
+
+import SwiftUI
+
+struct StopwatchTimerView: View {
+    var body: some View {
+        TabView {
+            Text("Timer View")
+            Text("Timer Image")
+        }
+        .tabViewStyle(.page)
+        .indexViewStyle(.page(backgroundDisplayMode: .always))
+        .frame(height: UIScreen.main.bounds.height * 0.55)
+    }
+}
+
+struct StopwatchTimerView_Previews: PreviewProvider {
+    static var previews: some View {
+        StopwatchTimerView()
+    }
+}

--- a/iClone_Clock/iClone_Clock/View/Stopwatch/StopwatchTimerView.swift
+++ b/iClone_Clock/iClone_Clock/View/Stopwatch/StopwatchTimerView.swift
@@ -9,12 +9,12 @@ import SwiftUI
 
 struct StopwatchTimerView: View {
     
-    @ObservedObject var observable: StopwatchObserable
+    @StateObject var observable: StopwatchObserable
     
     var body: some View {
         TabView {
             DigitalTimer
-            Text("Timer Image")
+            ImageTimer
         }
         .tabViewStyle(.page)
         .indexViewStyle(.page(backgroundDisplayMode: .always))
@@ -23,9 +23,61 @@ struct StopwatchTimerView: View {
     
     @ViewBuilder
     var DigitalTimer: some View {
-        Text("\(observable.counter + observable.laps.reduce(0, +))")
-            .font(.largeTitle)
+        let timer = observable.counter + observable.laps.reduce(0, +)
+        
+        Text(observable.formattedTime(timer))
             .monospacedDigit()
+            .font(.system(size: 100))
+            .fontWeight(.thin)
+            .minimumScaleFactor(0.5)
+            .lineLimit(1)
+            .padding(.horizontal)
+    }
+    
+    @ViewBuilder
+    var ImageTimer: some View {
+        
+        let totalSeconds = Double((observable.counter + observable.laps.reduce(0, +)) / 100 % 60)
+        let seconds = Double(observable.counter / 100 % 60)
+        
+        ZStack {
+            Circle()
+                .foregroundColor(Color(.systemGray6))
+                .overlay {
+                    if observable.counter == 0 {
+                        Rectangle()
+                            .frame(width: 3)
+                            .rotationEffect(.degrees(totalSeconds * 6), anchor: .center)
+                            .foregroundColor(.orange)
+                            .animation(.linear(duration: 0.1), value: totalSeconds)
+                    }
+                }
+                .overlay {
+                    if 1...6000 ~= observable.counter {
+                        Rectangle()
+                            .frame(width: 3)
+                            .rotationEffect(.degrees(seconds * 6), anchor: .center)
+                            .foregroundColor(.blue)
+                            .animation(.linear(duration: 1), value: seconds)
+                    }
+                }
+                .overlay {
+                    if 1...6000 ~= observable.counter {
+                        Rectangle()
+                            .frame(width: 3)
+                            .rotationEffect(.degrees(totalSeconds * 6), anchor: .center)
+                            .foregroundColor(.orange)
+                            .animation(.linear(duration: 1), value: totalSeconds)
+                    }
+                }
+            Circle()
+                .frame(width: 12)
+                .foregroundColor(.orange)
+            Circle()
+                .frame(width: 6)
+                .foregroundColor(Color(UIColor.systemBackground))
+        }
+        .padding()
     }
 }
 

--- a/iClone_Clock/iClone_Clock/View/Stopwatch/StopwatchTimerView.swift
+++ b/iClone_Clock/iClone_Clock/View/Stopwatch/StopwatchTimerView.swift
@@ -53,7 +53,7 @@ struct StopwatchTimerView: View {
                     }
                 }
                 .overlay {
-                    if 1...6000 ~= observable.counter {
+                    if 1...(60 * 100) ~= observable.counter {
                         Rectangle()
                             .frame(width: 3)
                             .rotationEffect(.degrees(seconds * 6), anchor: .center)
@@ -62,7 +62,7 @@ struct StopwatchTimerView: View {
                     }
                 }
                 .overlay {
-                    if 1...6000 ~= observable.counter {
+                    if 1...(60 * 100) ~= observable.counter {
                         Rectangle()
                             .frame(width: 3)
                             .rotationEffect(.degrees(totalSeconds * 6), anchor: .center)

--- a/iClone_Clock/iClone_Clock/View/Stopwatch/StopwatchTimerView.swift
+++ b/iClone_Clock/iClone_Clock/View/Stopwatch/StopwatchTimerView.swift
@@ -8,19 +8,29 @@
 import SwiftUI
 
 struct StopwatchTimerView: View {
+    
+    @ObservedObject var observable: StopwatchObserable
+    
     var body: some View {
         TabView {
-            Text("Timer View")
+            DigitalTimer
             Text("Timer Image")
         }
         .tabViewStyle(.page)
         .indexViewStyle(.page(backgroundDisplayMode: .always))
         .frame(height: UIScreen.main.bounds.height * 0.55)
     }
+    
+    @ViewBuilder
+    var DigitalTimer: some View {
+        Text("\(observable.counter + observable.laps.reduce(0, +))")
+            .font(.largeTitle)
+            .monospacedDigit()
+    }
 }
 
 struct StopwatchTimerView_Previews: PreviewProvider {
     static var previews: some View {
-        StopwatchTimerView()
+        StopwatchTimerView(observable: StopwatchObserable())
     }
 }

--- a/iClone_Clock/iClone_Clock/View/Stopwatch/StopwatchView.swift
+++ b/iClone_Clock/iClone_Clock/View/Stopwatch/StopwatchView.swift
@@ -15,6 +15,7 @@ struct StopwatchView: View {
     var body: some View {
         VStack(spacing: 0) {
             StopwatchTimerView(observable: observable)
+                .offset(y : -25)
                 .overlay(alignment: .bottom) {
                     HStack {
                         CircleButton(label: isStart ? "랩" : "재설정") {
@@ -44,9 +45,7 @@ struct StopwatchView: View {
                 .padding(.horizontal)
 
             
-            if isStart || !observable.laps.isEmpty {
-                LapListView(observable: observable)
-                    .scrollDisabled(false)
+            if isStart || observable.counter > 0 { LapListView(observable: observable)
             }
             Spacer()
         }

--- a/iClone_Clock/iClone_Clock/View/Stopwatch/StopwatchView.swift
+++ b/iClone_Clock/iClone_Clock/View/Stopwatch/StopwatchView.swift
@@ -9,33 +9,46 @@ import SwiftUI
 
 struct StopwatchView: View {
     
+    @StateObject var observable = StopwatchObserable()
     @State var isStart = false
     
     var body: some View {
         VStack(spacing: 0) {
-            StopwatchTimerView()
-            .overlay(alignment: .bottom) {
-                HStack {
-                    CircleButton(label: "랩") {
-                        
-                    }
-                    .foregroundColor(.primary)
-                    .disabled(!isStart)
-                    Spacer()
-                    CircleButton(label: isStart ? "중단" : "시작") {
-                        withAnimation() {
-                            isStart.toggle()
+            StopwatchTimerView(observable: observable)
+                .overlay(alignment: .bottom) {
+                    HStack {
+                        CircleButton(label: isStart ? "랩" : "재설정") {
+                            if isStart {
+                                observable.lapTimer()
+                            } else {
+                                observable.resetTimer()
+                            }
                         }
+                        .foregroundColor(.primary)
+                        Spacer()
+                        CircleButton(label: isStart ? "중단" : "시작") {
+                            isStart.toggle()
+                            if isStart {
+                                observable.startTimer()
+                            }
+                            else {
+                                observable.stopTimer()
+                            }
+                        }
+                        .foregroundColor(isStart ? .red : .green)
                     }
-                    .foregroundColor(isStart ? .red : .accentColor)
+                    .padding()
                 }
-                .padding()
-            }
             
             Divider()
                 .padding(.horizontal)
+
             
-            LapListView()
+            if isStart || !observable.laps.isEmpty {
+                LapListView(observable: observable)
+                    .scrollDisabled(false)
+            }
+            Spacer()
         }
     }
     

--- a/iClone_Clock/iClone_Clock/View/Stopwatch/StopwatchView.swift
+++ b/iClone_Clock/iClone_Clock/View/Stopwatch/StopwatchView.swift
@@ -8,8 +8,52 @@
 import SwiftUI
 
 struct StopwatchView: View {
+    
+    @State var isStart = false
+    
     var body: some View {
-        Text("Here is Stopwatch")
+        VStack(spacing: 0) {
+            StopwatchTimerView()
+            .overlay(alignment: .bottom) {
+                HStack {
+                    CircleButton(label: "랩") {
+                        
+                    }
+                    .foregroundColor(.primary)
+                    .disabled(!isStart)
+                    Spacer()
+                    CircleButton(label: isStart ? "중단" : "시작") {
+                        withAnimation() {
+                            isStart.toggle()
+                        }
+                    }
+                    .foregroundColor(isStart ? .red : .accentColor)
+                }
+                .padding()
+            }
+            
+            Divider()
+                .padding(.horizontal)
+            
+            LapListView()
+        }
+    }
+    
+    @ViewBuilder
+    private func CircleButton(label: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            ZStack {
+                Text(label)
+                Circle()
+                    .frame(width: 70)
+                    .foregroundStyle(.quaternary)
+                Circle()
+                    .stroke(lineWidth: 3)
+                    .frame(width: 76)
+                    .foregroundStyle(.quaternary)
+            }
+        }
+        .buttonStyle(.plain)
     }
 }
 


### PR DESCRIPTION
## 📌 Summary
<!-- 이슈 및 번호 (optional)
     이슈가 없다면 이 작업을 하게 된 이유 
     작업 내용 요약 -->
- #6
- 디지털 타이머 구현

<br>

## ✨ Description
- 00:00:00 으로 표시되는 디지털 타이머 구현
- 시작 버튼을 누를 시 타이머 시작 및 랩 버튼 활성화
- 시작 후 랩 버튼 누를시 아래 리스트에 랩 리스트 추가
- 중단 버튼을 누를 시 랩 버튼 재설정으로 변경
- 최대값 붉은색, 최솟값 초록색 표시

- 스크롤 시 타이머 멈춤현상 관련해서는 아래 노트 참고 부탁드립니다. (Combine 관련)

<br>

## 🏷️ Reference (optional)
<!-- 참고사항이나 레퍼런스 -->

<br>

## Screenshot
<!-- img src "이부분에 gif파일 넣어주시면 됩니다" -->
|기능|스크린샷|
|:--:|:--:|
|스톱워치|<img src = "https://github.com/SwiftDiggingClub/iClone_Clock/assets/120548537/398070f1-0850-4549-b28b-356130faf666" width ="250">|

<br>

## 🗒️ Note

### ‼️ 문제점 (해결 완료)
- 스크롤 할때 타이머가 멈추는 상황 발생
- 스크롤이 끝나고 나면 List의 맨 윗줄이 보이든 보이지 않든 타이머가 정상적으로 작동합니다.
- `scheduledTimer` 와 달리 `publish` 를 사용하면 항상 타이머가 정상적으로 작동

[`scheduledTimer` 사용 시 스크린샷]
<img src = "https://github.com/SwiftDiggingClub/iClone_Clock/assets/120548537/435c5c9f-4628-4337-94dd-bb9c6c72b62c" width ="250">

### 💡 해결과정
- 기존에 사용하였던 Stopwatch 로직은 다음과 같았습니다. `Timer.scheduledTimer` 로 타이머 관리를 했습니다.
- 또한 뷰에서 불러올때 `@StateObject var observable = StopwatchObserable()` 로 불러왔기 때문에 뷰가 로드될때 초기화 되는 문제도 아니였습니다.
```
class StopwatchObserable: ObservableObject {
    
    @Published var counter = 0
    @Published var laps: [Int] = []
    var timer = Timer()
    
    func startTimer() {
        timer = Timer.scheduledTimer(withTimeInterval: 0.01, repeats: true) { _ in
            self.counter += 1
        }
    }
    ...
}
```
- 타이머 생성방법에는 `Timer.publish(every:on:in:)`과 `Timer.scheduledTimer(withTimeInterval:repeats:block:)`의 두 가지가 있는데 이 둘의 차이점에 집중했습니다.

### `Timer.publish(every:on:in:)`
- Combine 프레임 워크에서 제공, 비동기 이벤트 스트림(Asynchronous Event Stream)을 생성합니다.
- 비동기 이벤트 스트림(Asynchronous Event Stream)은 비동기적으로 발생하는 이벤트나 데이터의 연속을 나타내는 개념입니다.
- 이벤트가 언제든지 발생할 수 있으며, 다른 이벤트나 작업과 독립적으로 발생할 수 있다는 것을 의미합니다.
- 데이터 변환 및 조작에 대한 더 많은 기능을 제공합니다.

### `Timer.scheduledTimer(withTimeInterval:repeats:block:)`
- Foundation 프레임워크에서 제공되며, GCD(Grand Central Dispatch)를 사용하여 비동기적으로 코드 블록을 실행하는 타이머를 생성합니다.
- GCD는 다양한 비동기 작업과 병렬 처리를 지원하는 데 사용된다고 합니다.
- 간단한 타이머 작업에 사용됩니다. 데이터를 Combine과 같은 이벤트 스트림으로 전달하지 않습니다.

### 둘다 비동기 작업인데 `scheduledTimer` 만 멈추는 이유
- `publish` 의 경우 Combine 프레임워크를 사용하여 스레드 블로킹이 발생하지 않는다고 합니다.
- `scheduledTimer` 의 경우 스크롤과 같은 사용자 입력을 처리하는데 시간이 오래걸리는 경우 이벤트 처리가 지연된다고 합니다.

### 🐥 해결 방안
- 타이머가 복잡한 비동기 작업이 필요하다면 `scheduledTimer` 말고 `publish` 를 사용합니다.

### 📖 같이 공부해봐요
- GCD가 Apple의 운영체제에서 다중 스레딩 및 병렬 처리를 지원하는 기술이라고 하는데 같이 디깅해보는것도 좋을 것 같아요
